### PR TITLE
ARCH-1690 - Adding a test job to the build-and-review-pr.yml

### DIFF
--- a/.github/workflows/build-and-review-pr.yml
+++ b/.github/workflows/build-and-review-pr.yml
@@ -62,3 +62,37 @@ jobs:
       # The npm script to run to build the action.  This is typically 'npm run build' if the
       # action needs to be compiled.  For composite-run-steps actions this is typically empty.
       build-command: '' # TODO:  Update if this action has a build step.
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      #--------------------------------------
+      # Setup
+      #--------------------------------------
+      - uses: actions/checkout@v3
+      # TODO:  add any additional steps needed to setup the test scenarios
+
+      # TODO:  Replace with the scenarios needed to test this action
+
+      #--------------------------------------
+      # SCENARIO 1
+      #--------------------------------------
+      - name: '-------------------------------------------------------------------------------------------------------'
+        run: echo ""
+
+      - name: When the repo is 'im-open/composite-action-template'
+        id: repo-check
+        run: |
+          if [ "${{ github.repository }}" != "im-open/composite-action-template" ]; then
+            exit 1
+          else
+            echo "SUCCESS=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Then the outcome should be success
+        if: always()
+        run: ./test/assert-values-match.sh --name "step outcome" --expected "success" --actual "${{ steps.repo-check.outcome }}"
+
+      - name: And the SUCCESS output should be true
+        if: always()
+        run: ./test/assert-values-match.sh --name "SUCCESS output" --expected "true" --actual "${{ steps.repo-check.outputs.SUCCESS }}"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This template can be used to quickly start a new custom composite-run-steps acti
     - [Incrementing the Version](#incrementing-the-version)
     - [Source Code Changes](#source-code-changes)
     - [Updating the README.md](#updating-the-readmemd)
+    - [Tests](#tests)
   - [Code of Conduct](#code-of-conduct)
   - [License](#license)
   
@@ -93,6 +94,7 @@ When creating PRs, please review the following guidelines:
 - [ ] The action code does not contain sensitive information.
 - [ ] At least one of the commit messages contains the appropriate `+semver:` keywords listed under [Incrementing the Version] for major and minor increments.
 - [ ] The README.md has been updated with the latest version of the action.  See [Updating the README.md] for details.
+- [ ] Any tests in the [build-and-review-pr] workflow are passing
 
 ### Incrementing the Version
 
@@ -117,6 +119,10 @@ If a PR consists solely of non-source code changes like changes to the `README.m
 ### Updating the README.md
 
 If changes are made to the action's [source code], the [usage examples] section of this file should be updated with the next version of the action.  Each instance of this action should be updated.  This helps users know what the latest tag is without having to navigate to the Tags page of the repository.  See [Incrementing the Version] for details on how to determine what the next version will be or consult the first workflow run for the PR which will also calculate the next version.
+
+### Tests
+
+The build and review PR workflow includes tests which are linked to a status check that needs to succeed before a PR is merged to the default branch.  When a PR comes from a branch there should not be any issues running the tests.  When a PR comes from a fork, tests may not have the required permissions or access to run since the `GITHUB_TOKEN` only has `read` access set for all scopes and fork's cannot access other secrets in the repository.  In these scenarios, a fork may need to be merged into an intermediate branch by the repository owners to ensure the tests run successfully prior to a merge to the default branch.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If changes are made to the action's [source code], the [usage examples] section 
 
 ### Tests
 
-The build and review PR workflow includes tests which are linked to a status check that needs to succeed before a PR is merged to the default branch.  When a PR comes from a branch there should not be any issues running the tests.  When a PR comes from a fork, tests may not have the required permissions or access to run since the `GITHUB_TOKEN` only has `read` access set for all scopes and fork's cannot access other secrets in the repository.  In these scenarios, a fork may need to be merged into an intermediate branch by the repository owners to ensure the tests run successfully prior to a merge to the default branch.
+The build and review PR workflow includes tests which are linked to a status check. That status check needs to succeed before a PR is merged to the default branch.  When a PR comes from a branch, there should not be any issues running the tests. When a PR comes from a fork, tests may not have the required permissions or access to run since the `GITHUB_TOKEN` only has `read` access set for all scopes. Also, forks cannot access other secrets in the repository.  In these scenarios, a fork may need to be merged into an intermediate branch by the repository owners to ensure the tests run successfully prior to merging to the default branch.
 
 ## Code of Conduct
 

--- a/test/assert-values-match.sh
+++ b/test/assert-values-match.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+name=''
+expectedValue=''
+actualValue=''
+
+for arg in "$@"; do
+    case $arg in
+    --name)
+        name=$2
+        shift # Remove argument --name from `$@`
+        shift # Remove argument value from `$@`
+        ;;
+    --expected)
+        expectedValue=$2
+        shift # Remove argument --expected from `$@`
+        shift # Remove argument value from `$@`
+        ;;
+    --actual)
+        actualValue=$2
+        shift # Remove argument --actual from `$@`
+        shift # Remove argument value from `$@`
+        ;;
+    
+    esac
+done
+
+echo "
+Expected $name: '$expectedValue'"
+echo "Actual $name:   '$actualValue'"
+
+if [ "$expectedValue" != "$actualValue" ]; then
+  echo "The expected $name does not match the actual $name."  
+  exit 1
+else 
+  echo "The expected and actual $name values match."
+fi


### PR DESCRIPTION
# Summary of PR changes

Adding a test job to the build-and-review-pr.yml.  This job will fail once it is cloned into another repo by design.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
